### PR TITLE
Add .NET Core 3.0 support (fixes #1)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 only_commits:
   files: src
 
-version: 2.0.{build}
+version: 3.0.{build}
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 only_commits:
   files: src
 
-version: 3.0.{build}
+version: 2.1.{build}
 
 image: Visual Studio 2019
 

--- a/src/Linquest.AspNetCore/Linquest.AspNetCore.csproj
+++ b/src/Linquest.AspNetCore/Linquest.AspNetCore.csproj
@@ -14,19 +14,27 @@
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <DefineConstants>NETSTANDARD2_0</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+        <DefineConstants>NETCOREAPP3_0</DefineConstants>
+    </PropertyGroup>
+    
     <ItemGroup>
-        <PackageReference Include="DynamicQueryable" Version="2.0.25" />
+        <PackageReference Include="DynamicQueryable" Version="2.0.25"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0"/>
     </ItemGroup>
 
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
         <!--        <PackageReference Include="Microsoft.AspNetCore.App" Version="3.0.0"/>-->
-<!--        <FrameworkReference Include="Microsoft.AspNetCore.App"/>-->
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <!--        <FrameworkReference Include="Microsoft.AspNetCore.App"/>-->
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
 
 

--- a/src/Linquest.AspNetCore/Linquest.AspNetCore.csproj
+++ b/src/Linquest.AspNetCore/Linquest.AspNetCore.csproj
@@ -1,27 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Description>Create client queryable API endpoints.</Description>
-    <Authors>Umut Özel</Authors>
-    <Copyright>Copyright (c) 2018</Copyright>
-    <PackageLicenseUrl>https://github.com/jin-qu/Linquest.AspNetCore/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/jin-qu/Linquest.AspNetCore</PackageProjectUrl>
-    <PackageIconUrl>https://image.ibb.co/kYhmu9/api.png</PackageIconUrl>
-    <PackageTags>csharp controller action api webapi iqueryable linq</PackageTags>
-    <RepositoryUrl>https://github.com/jin-qu/Linquest.AspNetCore</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <Description>Create client queryable API endpoints.</Description>
+        <Authors>Umut Özel</Authors>
+        <Copyright>Copyright (c) 2018</Copyright>
+        <PackageLicenseUrl>https://github.com/jin-qu/Linquest.AspNetCore/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageProjectUrl>https://github.com/jin-qu/Linquest.AspNetCore</PackageProjectUrl>
+        <PackageIconUrl>https://image.ibb.co/kYhmu9/api.png</PackageIconUrl>
+        <PackageTags>csharp controller action api webapi iqueryable linq</PackageTags>
+        <RepositoryUrl>https://github.com/jin-qu/Linquest.AspNetCore</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DynamicQueryable" Version="2.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="DynamicQueryable" Version="2.0.25" />
+    </ItemGroup>
 
-  <PropertyGroup>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-  
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
+    </ItemGroup>
+
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+        <!--        <PackageReference Include="Microsoft.AspNetCore.App" Version="3.0.0"/>-->
+<!--        <FrameworkReference Include="Microsoft.AspNetCore.App"/>-->
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+
+    <PropertyGroup>
+        <DebugType>full</DebugType>
+        <DebugSymbols>True</DebugSymbols>
+    </PropertyGroup>
+
 </Project>

--- a/src/Linquest.AspNetCore/Linquest.AspNetCore.csproj
+++ b/src/Linquest.AspNetCore/Linquest.AspNetCore.csproj
@@ -21,7 +21,7 @@
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
         <DefineConstants>NETCOREAPP3_0</DefineConstants>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="DynamicQueryable" Version="2.0.25"/>
     </ItemGroup>
@@ -29,15 +29,11 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0"/>
     </ItemGroup>
-
-
+    
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-        <!--        <PackageReference Include="Microsoft.AspNetCore.App" Version="3.0.0"/>-->
-        <!--        <FrameworkReference Include="Microsoft.AspNetCore.App"/>-->
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
-
-
+    
     <PropertyGroup>
         <DebugType>full</DebugType>
         <DebugSymbols>True</DebugSymbols>

--- a/src/Linquest.AspNetCore/QueryableHandler.cs
+++ b/src/Linquest.AspNetCore/QueryableHandler.cs
@@ -5,22 +5,27 @@ using System.Linq.Dynamic;
 using System.Reflection;
 using Linquest.AspNetCore;
 
-namespace Linquest.AspNetCore {
+namespace Linquest.AspNetCore
+{
     using Interface;
 
-    public class QueryableHandler : IContentHandler<IQueryable> {
+    public class QueryableHandler : IContentHandler<IQueryable>
+    {
         private static readonly Lazy<QueryableHandler> _instance = new Lazy<QueryableHandler>();
 
-        public virtual ProcessResult HandleContent(object query, ActionContext context) {
-            return HandleContent((IQueryable)query, context);
+        public virtual ProcessResult HandleContent(object query, ActionContext context)
+        {
+            return HandleContent((IQueryable) query, context);
         }
 
-        public virtual ProcessResult HandleContent(IQueryable query, ActionContext context) {
+        public virtual ProcessResult HandleContent(IQueryable query, ActionContext context)
+        {
             if (query == null) throw new ArgumentNullException(nameof(query));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var service = context.Service;
-            if (service != null) {
+            if (service != null)
+            {
                 var args = new BeforeQueryEventArgs(context, query);
                 service.OnBeforeHandleQuery(args);
                 query = args.Query;
@@ -33,8 +38,10 @@ namespace Linquest.AspNetCore {
             var inlineCountEnabled = false;
             int? takeCount = null;
             IQueryable inlineCountQuery = null;
-            foreach (var prm in parameters) {
-                switch (prm.Name.ToLowerInvariant()) {
+            foreach (var prm in parameters)
+            {
+                switch (prm.Name.ToLowerInvariant())
+                {
                     case "$inlinecount":
                         inlineCountEnabled = prm.Value != "false" || prm.Value == "allpages";
                         break;
@@ -59,16 +66,20 @@ namespace Linquest.AspNetCore {
                         query = Select(query, prm.Value);
                         break;
                     case "$skip":
-                        if (inlineCountEnabled && inlineCountQuery == null) {
+                        if (inlineCountEnabled && inlineCountQuery == null)
+                        {
                             inlineCountQuery = query;
                         }
+
                         query = Skip(query, Convert.ToInt32(prm.Value));
                         break;
                     case "$top":
                     case "$take":
-                        if (inlineCountEnabled && inlineCountQuery == null) {
+                        if (inlineCountEnabled && inlineCountQuery == null)
+                        {
                             inlineCountQuery = query;
                         }
+
                         var take = Convert.ToInt32(prm.Value);
                         query = Take(query, take);
                         takeCount = take;
@@ -148,146 +159,183 @@ namespace Linquest.AspNetCore {
             return CreateResult(context, query, takeCount, inlineCountQuery);
         }
 
-        public virtual IQueryable Where(IQueryable query, string filter) {
+        public virtual IQueryable Where(IQueryable query, string filter)
+        {
             return query.Where(filter);
         }
 
-        public virtual IQueryable OrderBy(IQueryable query, string orderBy) {
+        public virtual IQueryable OrderBy(IQueryable query, string orderBy)
+        {
             return query.OrderBy(orderBy);
         }
 
-        public virtual IQueryable OrderbyDescending(IQueryable query, string orderBy) {
+        public virtual IQueryable OrderbyDescending(IQueryable query, string orderBy)
+        {
             return query.OrderByDescending(orderBy);
         }
 
-        public virtual IQueryable ThenBy(IQueryable query, string orderBy) {
+        public virtual IQueryable ThenBy(IQueryable query, string orderBy)
+        {
             return query.ThenBy(orderBy);
         }
 
-        public virtual IQueryable ThenByDescending(IQueryable query, string orderBy) {
+        public virtual IQueryable ThenByDescending(IQueryable query, string orderBy)
+        {
             return query.ThenByDescending(orderBy);
         }
 
-        public virtual IQueryable Select(IQueryable query, string projection) {
+        public virtual IQueryable Select(IQueryable query, string projection)
+        {
             return query.Select(projection);
         }
 
-        public virtual IQueryable Skip(IQueryable query, int count) {
+        public virtual IQueryable Skip(IQueryable query, int count)
+        {
             return query.Skip(count);
         }
 
-        public virtual IQueryable Take(IQueryable query, int count) {
+        public virtual IQueryable Take(IQueryable query, int count)
+        {
             return query.Take(count);
         }
 
-        public virtual IQueryable GroupBy(IQueryable query, string keySelector, string elementSelector) {
+        public virtual IQueryable GroupBy(IQueryable query, string keySelector, string elementSelector)
+        {
             return string.IsNullOrWhiteSpace(elementSelector)
+#if NETSTANDARD2_0
                 ? query.GroupBy(keySelector)
+#elif NETCOREAPP3_0
+                //INFO: List<IGrouping<Item>> can't be serialized using default ASP.NET Core 3.0 serializer
+                ? query.GroupBy(keySelector, "(key, group) => group")
+#endif
                 : query.GroupBy(keySelector, elementSelector);
         }
 
-        public virtual IQueryable Distinct(IQueryable query) {
+        public virtual IQueryable Distinct(IQueryable query)
+        {
             return query.Distinct();
         }
 
-        public virtual IQueryable Reverse(IQueryable query) {
-            return Queryable.Reverse((dynamic)query);
+        public virtual IQueryable Reverse(IQueryable query)
+        {
+            return Queryable.Reverse((dynamic) query);
         }
 
-        public virtual IQueryable SelectMany(IQueryable query, string projection) {
+        public virtual IQueryable SelectMany(IQueryable query, string projection)
+        {
             return string.IsNullOrWhiteSpace(projection) ? query : query.SelectMany(projection);
         }
 
-        public virtual IQueryable SkipWhile(IQueryable query, string predicate) {
+        public virtual IQueryable SkipWhile(IQueryable query, string predicate)
+        {
             return query.SkipWhile(predicate);
         }
 
-        public virtual IQueryable TakeWhile(IQueryable query, string predicate) {
+        public virtual IQueryable TakeWhile(IQueryable query, string predicate)
+        {
             return query.TakeWhile(predicate);
         }
 
-        public virtual object Aggregate(IQueryable query, string func, string seed = null) {
+        public virtual object Aggregate(IQueryable query, string func, string seed = null)
+        {
             return string.IsNullOrWhiteSpace(seed)
                 ? query.Aggregate(func)
                 : query.Aggregate(Convert.ToDouble(seed), func);
         }
 
-        public virtual bool All(IQueryable query, string predicate) {
+        public virtual bool All(IQueryable query, string predicate)
+        {
             return query.All(predicate);
         }
 
-        public virtual bool Any(IQueryable query, string predicate) {
+        public virtual bool Any(IQueryable query, string predicate)
+        {
             return query.Any(predicate);
         }
 
-        public virtual object Avg(IQueryable query, string elementSelector) {
+        public virtual object Avg(IQueryable query, string elementSelector)
+        {
             return query.Average(elementSelector);
         }
 
-        public virtual object Max(IQueryable query, string elementSelector) {
+        public virtual object Max(IQueryable query, string elementSelector)
+        {
             return query.Max(elementSelector);
         }
 
-        public virtual object Min(IQueryable query, string elementSelector) {
+        public virtual object Min(IQueryable query, string elementSelector)
+        {
             return query.Min(elementSelector);
         }
 
-        public virtual object Sum(IQueryable query, string elementSelector) {
+        public virtual object Sum(IQueryable query, string elementSelector)
+        {
             return query.Sum(elementSelector);
         }
 
-        public virtual object Count(IQueryable query, string predicate) {
+        public virtual object Count(IQueryable query, string predicate)
+        {
             return query.Count(predicate);
         }
 
-        public virtual object First(IQueryable query, string predicate) {
+        public virtual object First(IQueryable query, string predicate)
+        {
             return query.First(predicate);
         }
 
-        public virtual object FirstOrDefault(IQueryable query, string predicate) {
+        public virtual object FirstOrDefault(IQueryable query, string predicate)
+        {
             return query.FirstOrDefault(predicate);
         }
 
-        public virtual object Single(IQueryable query, string predicate) {
+        public virtual object Single(IQueryable query, string predicate)
+        {
             return query.Single(predicate);
         }
 
-        public virtual object SingleOrDefault(IQueryable query, string predicate) {
+        public virtual object SingleOrDefault(IQueryable query, string predicate)
+        {
             return query.SingleOrDefault(predicate);
         }
 
-        public virtual object Last(IQueryable query, string predicate) {
+        public virtual object Last(IQueryable query, string predicate)
+        {
             return query.Last(predicate);
         }
 
-        public virtual object LastOrDefault(IQueryable query, string predicate) {
+        public virtual object LastOrDefault(IQueryable query, string predicate)
+        {
             return query.LastOrDefault(predicate);
         }
 
-        public virtual object ElementAt(IQueryable query, int index) {
+        public virtual object ElementAt(IQueryable query, int index)
+        {
             return query.ElementAt(index);
         }
 
-        public virtual object ElementAtOrDefault(IQueryable query, int index) {
+        public virtual object ElementAtOrDefault(IQueryable query, int index)
+        {
             return query.ElementAtOrDefault(index);
         }
 
-        protected static ProcessResult CreateResult(ActionContext context, IQueryable query, int? takeCount, IQueryable inlineCountQuery) {
+        protected static ProcessResult CreateResult(ActionContext context, IQueryable query, int? takeCount, IQueryable inlineCountQuery)
+        {
             int? max = context.MaxResultCount ?? context.Service?.MaxResultCount;
-            if (max > 0) {
-                var count = takeCount ?? Queryable.Count((dynamic)query);
+            if (max > 0)
+            {
+                var count = takeCount ?? Queryable.Count((dynamic) query);
                 if (count > max) throw new Exception($"Maximum allowed read count exceeded");
             }
 
             var service = context.Service;
             if (service == null)
-                return CreateResult(context, Enumerable.ToList((dynamic)query), inlineCountQuery);
+                return CreateResult(context, Enumerable.ToList((dynamic) query), inlineCountQuery);
 
             var beforeArgs = new BeforeQueryEventArgs(context, query);
             service.OnBeforeQueryExecute(beforeArgs);
             query = beforeArgs.Query;
 
-            var result = Enumerable.ToList((dynamic)query);
+            var result = Enumerable.ToList((dynamic) query);
             var afterArgs = new AfterQueryEventArgs(context, query, result);
             service.OnAfterQueryExecute(afterArgs);
             result = afterArgs.Result;
@@ -295,9 +343,10 @@ namespace Linquest.AspNetCore {
             return CreateResult(context, result, inlineCountQuery);
         }
 
-        protected static ProcessResult CreateResult(ActionContext context, object result, IQueryable inlineCountQuery) {
-            int? inlineCount = inlineCountQuery != null ? Queryable.Count((dynamic)inlineCountQuery) : null;
-            return new ProcessResult(context) { Result = result, InlineCount = inlineCount };
+        protected static ProcessResult CreateResult(ActionContext context, object result, IQueryable inlineCountQuery)
+        {
+            int? inlineCount = inlineCountQuery != null ? Queryable.Count((dynamic) inlineCountQuery) : null;
+            return new ProcessResult(context) {Result = result, InlineCount = inlineCount};
         }
 
         public static QueryableHandler Instance => _instance.Value;

--- a/src/Linquest.AspNetCore/QueryableHandler.cs
+++ b/src/Linquest.AspNetCore/QueryableHandler.cs
@@ -1,31 +1,23 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic;
-using System.Reflection;
-using Linquest.AspNetCore;
 
-namespace Linquest.AspNetCore
-{
+namespace Linquest.AspNetCore {
     using Interface;
 
-    public class QueryableHandler : IContentHandler<IQueryable>
-    {
+    public class QueryableHandler : IContentHandler<IQueryable> {
         private static readonly Lazy<QueryableHandler> _instance = new Lazy<QueryableHandler>();
 
-        public virtual ProcessResult HandleContent(object query, ActionContext context)
-        {
-            return HandleContent((IQueryable) query, context);
+        public virtual ProcessResult HandleContent(object query, ActionContext context) {
+            return HandleContent((IQueryable)query, context);
         }
 
-        public virtual ProcessResult HandleContent(IQueryable query, ActionContext context)
-        {
+        public virtual ProcessResult HandleContent(IQueryable query, ActionContext context) {
             if (query == null) throw new ArgumentNullException(nameof(query));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var service = context.Service;
-            if (service != null)
-            {
+            if (service != null) {
                 var args = new BeforeQueryEventArgs(context, query);
                 service.OnBeforeHandleQuery(args);
                 query = args.Query;
@@ -38,10 +30,8 @@ namespace Linquest.AspNetCore
             var inlineCountEnabled = false;
             int? takeCount = null;
             IQueryable inlineCountQuery = null;
-            foreach (var prm in parameters)
-            {
-                switch (prm.Name.ToLowerInvariant())
-                {
+            foreach (var prm in parameters) {
+                switch (prm.Name.ToLowerInvariant()) {
                     case "$inlinecount":
                         inlineCountEnabled = prm.Value != "false" || prm.Value == "allpages";
                         break;
@@ -66,8 +56,7 @@ namespace Linquest.AspNetCore
                         query = Select(query, prm.Value);
                         break;
                     case "$skip":
-                        if (inlineCountEnabled && inlineCountQuery == null)
-                        {
+                        if (inlineCountEnabled && inlineCountQuery == null) {
                             inlineCountQuery = query;
                         }
 
@@ -75,8 +64,7 @@ namespace Linquest.AspNetCore
                         break;
                     case "$top":
                     case "$take":
-                        if (inlineCountEnabled && inlineCountQuery == null)
-                        {
+                        if (inlineCountEnabled && inlineCountQuery == null) {
                             inlineCountQuery = query;
                         }
 
@@ -159,48 +147,39 @@ namespace Linquest.AspNetCore
             return CreateResult(context, query, takeCount, inlineCountQuery);
         }
 
-        public virtual IQueryable Where(IQueryable query, string filter)
-        {
+        public virtual IQueryable Where(IQueryable query, string filter) {
             return query.Where(filter);
         }
 
-        public virtual IQueryable OrderBy(IQueryable query, string orderBy)
-        {
+        public virtual IQueryable OrderBy(IQueryable query, string orderBy) {
             return query.OrderBy(orderBy);
         }
 
-        public virtual IQueryable OrderbyDescending(IQueryable query, string orderBy)
-        {
+        public virtual IQueryable OrderbyDescending(IQueryable query, string orderBy) {
             return query.OrderByDescending(orderBy);
         }
 
-        public virtual IQueryable ThenBy(IQueryable query, string orderBy)
-        {
+        public virtual IQueryable ThenBy(IQueryable query, string orderBy) {
             return query.ThenBy(orderBy);
         }
 
-        public virtual IQueryable ThenByDescending(IQueryable query, string orderBy)
-        {
+        public virtual IQueryable ThenByDescending(IQueryable query, string orderBy) {
             return query.ThenByDescending(orderBy);
         }
 
-        public virtual IQueryable Select(IQueryable query, string projection)
-        {
+        public virtual IQueryable Select(IQueryable query, string projection) {
             return query.Select(projection);
         }
 
-        public virtual IQueryable Skip(IQueryable query, int count)
-        {
+        public virtual IQueryable Skip(IQueryable query, int count) {
             return query.Skip(count);
         }
 
-        public virtual IQueryable Take(IQueryable query, int count)
-        {
+        public virtual IQueryable Take(IQueryable query, int count) {
             return query.Take(count);
         }
 
-        public virtual IQueryable GroupBy(IQueryable query, string keySelector, string elementSelector)
-        {
+        public virtual IQueryable GroupBy(IQueryable query, string keySelector, string elementSelector) {
             return string.IsNullOrWhiteSpace(elementSelector)
 #if NETSTANDARD2_0
                 ? query.GroupBy(keySelector)
@@ -211,131 +190,108 @@ namespace Linquest.AspNetCore
                 : query.GroupBy(keySelector, elementSelector);
         }
 
-        public virtual IQueryable Distinct(IQueryable query)
-        {
+        public virtual IQueryable Distinct(IQueryable query) {
             return query.Distinct();
         }
 
-        public virtual IQueryable Reverse(IQueryable query)
-        {
-            return Queryable.Reverse((dynamic) query);
+        public virtual IQueryable Reverse(IQueryable query) {
+            return Queryable.Reverse((dynamic)query);
         }
 
-        public virtual IQueryable SelectMany(IQueryable query, string projection)
-        {
+        public virtual IQueryable SelectMany(IQueryable query, string projection) {
             return string.IsNullOrWhiteSpace(projection) ? query : query.SelectMany(projection);
         }
 
-        public virtual IQueryable SkipWhile(IQueryable query, string predicate)
-        {
+        public virtual IQueryable SkipWhile(IQueryable query, string predicate) {
             return query.SkipWhile(predicate);
         }
 
-        public virtual IQueryable TakeWhile(IQueryable query, string predicate)
-        {
+        public virtual IQueryable TakeWhile(IQueryable query, string predicate) {
             return query.TakeWhile(predicate);
         }
 
-        public virtual object Aggregate(IQueryable query, string func, string seed = null)
-        {
+        public virtual object Aggregate(IQueryable query, string func, string seed = null) {
             return string.IsNullOrWhiteSpace(seed)
                 ? query.Aggregate(func)
                 : query.Aggregate(Convert.ToDouble(seed), func);
         }
 
-        public virtual bool All(IQueryable query, string predicate)
-        {
+        public virtual bool All(IQueryable query, string predicate) {
             return query.All(predicate);
         }
 
-        public virtual bool Any(IQueryable query, string predicate)
-        {
+        public virtual bool Any(IQueryable query, string predicate) {
             return query.Any(predicate);
         }
 
-        public virtual object Avg(IQueryable query, string elementSelector)
-        {
+        public virtual object Avg(IQueryable query, string elementSelector) {
             return query.Average(elementSelector);
         }
 
-        public virtual object Max(IQueryable query, string elementSelector)
-        {
+        public virtual object Max(IQueryable query, string elementSelector) {
             return query.Max(elementSelector);
         }
 
-        public virtual object Min(IQueryable query, string elementSelector)
-        {
+        public virtual object Min(IQueryable query, string elementSelector) {
             return query.Min(elementSelector);
         }
 
-        public virtual object Sum(IQueryable query, string elementSelector)
-        {
+        public virtual object Sum(IQueryable query, string elementSelector) {
             return query.Sum(elementSelector);
         }
 
-        public virtual object Count(IQueryable query, string predicate)
-        {
+        public virtual object Count(IQueryable query, string predicate) {
             return query.Count(predicate);
         }
 
-        public virtual object First(IQueryable query, string predicate)
-        {
+        public virtual object First(IQueryable query, string predicate) {
             return query.First(predicate);
         }
 
-        public virtual object FirstOrDefault(IQueryable query, string predicate)
-        {
+        public virtual object FirstOrDefault(IQueryable query, string predicate) {
             return query.FirstOrDefault(predicate);
         }
 
-        public virtual object Single(IQueryable query, string predicate)
-        {
+        public virtual object Single(IQueryable query, string predicate) {
             return query.Single(predicate);
         }
 
-        public virtual object SingleOrDefault(IQueryable query, string predicate)
-        {
+        public virtual object SingleOrDefault(IQueryable query, string predicate) {
             return query.SingleOrDefault(predicate);
         }
 
-        public virtual object Last(IQueryable query, string predicate)
-        {
+        public virtual object Last(IQueryable query, string predicate) {
             return query.Last(predicate);
         }
 
-        public virtual object LastOrDefault(IQueryable query, string predicate)
-        {
+        public virtual object LastOrDefault(IQueryable query, string predicate) {
             return query.LastOrDefault(predicate);
         }
 
-        public virtual object ElementAt(IQueryable query, int index)
-        {
+        public virtual object ElementAt(IQueryable query, int index) {
             return query.ElementAt(index);
         }
 
-        public virtual object ElementAtOrDefault(IQueryable query, int index)
-        {
+        public virtual object ElementAtOrDefault(IQueryable query, int index) {
             return query.ElementAtOrDefault(index);
         }
 
-        protected static ProcessResult CreateResult(ActionContext context, IQueryable query, int? takeCount, IQueryable inlineCountQuery)
-        {
+        protected static ProcessResult CreateResult(ActionContext context, IQueryable query, int? takeCount, IQueryable inlineCountQuery) {
             int? max = context.MaxResultCount ?? context.Service?.MaxResultCount;
-            if (max > 0)
-            {
-                var count = takeCount ?? Queryable.Count((dynamic) query);
+            if (max > 0) {
+                var count = takeCount ?? Queryable.Count((dynamic)query);
                 if (count > max) throw new Exception($"Maximum allowed read count exceeded");
             }
 
             var service = context.Service;
             if (service == null)
-                return CreateResult(context, Enumerable.ToList((dynamic) query), inlineCountQuery);
+                return CreateResult(context, Enumerable.ToList((dynamic)query), inlineCountQuery);
 
             var beforeArgs = new BeforeQueryEventArgs(context, query);
             service.OnBeforeQueryExecute(beforeArgs);
             query = beforeArgs.Query;
 
-            var result = Enumerable.ToList((dynamic) query);
+            var result = Enumerable.ToList((dynamic)query);
             var afterArgs = new AfterQueryEventArgs(context, query, result);
             service.OnAfterQueryExecute(afterArgs);
             result = afterArgs.Result;
@@ -343,10 +299,9 @@ namespace Linquest.AspNetCore
             return CreateResult(context, result, inlineCountQuery);
         }
 
-        protected static ProcessResult CreateResult(ActionContext context, object result, IQueryable inlineCountQuery)
-        {
-            int? inlineCount = inlineCountQuery != null ? Queryable.Count((dynamic) inlineCountQuery) : null;
-            return new ProcessResult(context) {Result = result, InlineCount = inlineCount};
+        protected static ProcessResult CreateResult(ActionContext context, object result, IQueryable inlineCountQuery) {
+            int? inlineCount = inlineCountQuery != null ? Queryable.Count((dynamic)inlineCountQuery) : null;
+            return new ProcessResult(context) { Result = result, InlineCount = inlineCount };
         }
 
         public static QueryableHandler Instance => _instance.Value;

--- a/test/Linquest.AspNetCore.Tests/Fixture/Startup.cs
+++ b/test/Linquest.AspNetCore.Tests/Fixture/Startup.cs
@@ -5,25 +5,46 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Linquest.AspNetCore.Tests.Fixture {
+namespace Linquest.AspNetCore.Tests.Fixture
+{
     using Interface;
     using Model;
 
-    public class Startup : StartupBase {
-
+    public class Startup : StartupBase
+    {
         public IConfiguration Configuration { get; }
 
-        public Startup(IConfiguration configuration) {
+        public Startup(IConfiguration configuration)
+        {
             Configuration = configuration;
         }
 
-        public override void ConfigureServices(IServiceCollection services) {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+#if NETCOREAPP2_1
             services.AddMvc();
             services.AddMvc().AddApplicationPart(typeof(Startup).Assembly);
-
+#elif NETCOREAPP3_0
+            services.AddControllers();
+#endif
             services.AddSingleton<IContentHandler<Product>, ProductHandler>();
         }
 
-        public override void Configure(IApplicationBuilder app) => app.UseMvc();
+        public override void Configure(IApplicationBuilder app)
+        {
+#if NETCOREAPP2_1
+            app.UseMvc();
+#elif NETCOREAPP3_0
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+                
+                endpoints.MapControllers();
+            });
+#endif
+        }
     }
 }

--- a/test/Linquest.AspNetCore.Tests/Fixture/Startup.cs
+++ b/test/Linquest.AspNetCore.Tests/Fixture/Startup.cs
@@ -1,26 +1,20 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Linquest.AspNetCore.Tests.Fixture
-{
+namespace Linquest.AspNetCore.Tests.Fixture {
     using Interface;
     using Model;
 
-    public class Startup : StartupBase
-    {
+    public class Startup : StartupBase {
         public IConfiguration Configuration { get; }
 
-        public Startup(IConfiguration configuration)
-        {
+        public Startup(IConfiguration configuration) {
             Configuration = configuration;
         }
 
-        public override void ConfigureServices(IServiceCollection services)
-        {
+        public override void ConfigureServices(IServiceCollection services) {
 #if NETCOREAPP2_1
             services.AddMvc();
             services.AddMvc().AddApplicationPart(typeof(Startup).Assembly);
@@ -30,8 +24,7 @@ namespace Linquest.AspNetCore.Tests.Fixture
             services.AddSingleton<IContentHandler<Product>, ProductHandler>();
         }
 
-        public override void Configure(IApplicationBuilder app)
-        {
+        public override void Configure(IApplicationBuilder app) {
 #if NETCOREAPP2_1
             app.UseMvc();
 #elif NETCOREAPP3_0

--- a/test/Linquest.AspNetCore.Tests/Fixture/Test2Controller.cs
+++ b/test/Linquest.AspNetCore.Tests/Fixture/Test2Controller.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace Linquest.AspNetCore.Tests.Fixture {
     using Model;

--- a/test/Linquest.AspNetCore.Tests/Fixture/TestController.cs
+++ b/test/Linquest.AspNetCore.Tests/Fixture/TestController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace Linquest.AspNetCore.Tests.Fixture {
     using Model;

--- a/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
+++ b/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
         <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1" />
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
+++ b/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
@@ -6,26 +6,26 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0"/>
-        <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0"/>
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-        <PackageReference Include="Microsoft.AspNetCore.All"/>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.All" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Linquest.AspNetCore\Linquest.AspNetCore.csproj"/>
+        <ProjectReference Include="..\..\src\Linquest.AspNetCore\Linquest.AspNetCore.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
+++ b/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
@@ -5,6 +5,14 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+        <DefineConstants>NETCOREAPP2_1</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+        <DefineConstants>NETCOREAPP3_0</DefineConstants>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
+++ b/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0"/>
     </ItemGroup>
 

--- a/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
+++ b/test/Linquest.AspNetCore.Tests/Linquest.AspNetCore.Tests.csproj
@@ -1,24 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
+        <PackageReference Include="coverlet.msbuild" Version="2.7.0"/>
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="coverlet.msbuild" Version="2.3.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+        <PackageReference Include="Microsoft.AspNetCore.All"/>
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Linquest.AspNetCore\Linquest.AspNetCore.csproj" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Linquest.AspNetCore\Linquest.AspNetCore.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/test/Linquest.AspNetCore.Tests/QueryTests.cs
+++ b/test/Linquest.AspNetCore.Tests/QueryTests.cs
@@ -10,15 +10,18 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace Linquest.AspNetCore.Tests {
+namespace Linquest.AspNetCore.Tests
+{
     using Fixture;
     using Fixture.Model;
 
-    public class QueryTests {
-
+    public class QueryTests
+    {
         [Fact]
-        public async Task ShouldAccessController() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldAccessController()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var value = await client.GetStringAsync("api/Test");
 
@@ -27,8 +30,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldReturnNull() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldReturnNull()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var content = await client.GetStringAsync("api/Test/NullValue");
                 var dynContent = JObject.Parse(content);
@@ -38,8 +43,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetFilteredOrders() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetFilteredOrders()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -53,8 +60,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetFilteredOrdersFromNativeController() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetFilteredOrdersFromNativeController()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test2/Orders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -68,8 +77,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldNotFilterEnumerableOrders() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldNotFilterEnumerableOrders()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/EnumerableOrders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -81,8 +92,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldNotFilterNonLinquestOrders() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldNotFilterNonLinquestOrders()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/NonLinquestOrders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -93,8 +106,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldSkipJsonResult() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldSkipJsonResult()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/JsonOrders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -106,8 +121,10 @@ namespace Linquest.AspNetCore.Tests {
 
 
         [Fact]
-        public async Task ShouldGetSortedOrders() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetSortedOrders()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
 
                 var url1 = $"api/Test/Orders?$orderBy={WebUtility.UrlEncode("o => o.Price")}&$thenByDescending={WebUtility.UrlEncode("o => o.Id")}";
@@ -131,8 +148,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldProjectOrders() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldProjectOrders()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$select={WebUtility.UrlEncode("o => new { o.Id, o.No }")}";
                 var content = await client.GetStringAsync(url);
@@ -147,8 +166,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetOrdersIdGreaterThan2() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetOrdersIdGreaterThan2()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$skipWhile={WebUtility.UrlEncode("o => o.Id < 3")}";
                 var content = await client.GetStringAsync(url);
@@ -162,8 +183,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetOrdersIdLessThan3() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetOrdersIdLessThan3()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$takeWhile={WebUtility.UrlEncode("o => o.Id < 3")}";
                 var content = await client.GetStringAsync(url);
@@ -177,8 +200,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetPageData() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetPageData()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
 
                 var url1 = "api/Test/Orders?$inlineCount=allpages&$skip=2&$take=2";
@@ -217,8 +242,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGroupByCustomer() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGroupByCustomer()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
 
                 var url1 = $"api/Test/Orders?$groupBy={WebUtility.UrlEncode("o => o.Price")};{WebUtility.UrlEncode("(k, g) => g.Count()")}";
@@ -226,27 +253,38 @@ namespace Linquest.AspNetCore.Tests {
                 var dynContent1 = JObject.Parse(content1);
                 var counts = dynContent1["d"].ToObject<List<int>>();
 
-                Assert.Equal(new[] { 1, 1, 2, 1 }, counts);
+                Assert.Equal(new[] {1, 1, 2, 1}, counts);
 
                 var url2 = $"api/Test/Orders?$groupBy={WebUtility.UrlEncode("o => o.Price")}";
                 var content2 = await client.GetStringAsync(url2);
                 var dynContent2 = JObject.Parse(content2);
-                var groups = dynContent2["d"].ToObject<List<List<Order>>>();
+                var groups2 = dynContent2["d"].ToObject<List<List<Order>>>();
+
+                Assert.Single(groups2[0]);
+                Assert.Single(groups2[1]);
+                Assert.Equal(2, groups2[2].Count);
+                Assert.Single(groups2[3]);
+                
+                var url3 = $"api/Test/Orders?$groupBy={WebUtility.UrlEncode("o => o.Price")};{WebUtility.UrlEncode("(k, g) => g")}";
+                var content3 = await client.GetStringAsync(url3);
+                var dynContent3 = JObject.Parse(content3);
+                var groups = dynContent3["d"].ToObject<List<List<Order>>>();
 
                 Assert.Single(groups[0]);
                 Assert.Single(groups[1]);
                 Assert.Equal(2, groups[2].Count);
                 Assert.Single(groups[3]);
 
-                var url3 = $"api/Test/Orders?$groupBy=a;b;c";
-
-                await Assert.ThrowsAsync<Exception>(() => client.GetStringAsync(url3));
+                var url4 = $"api/Test/Orders?$groupBy=a;b;c";
+                await Assert.ThrowsAsync<Exception>(() => client.GetStringAsync(url4));
             }
         }
 
         [Fact]
-        public async Task ShouldGetDistinctPriceCount() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetDistinctPriceCount()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$select={WebUtility.UrlEncode("o => o.Price")}&$distinct&$count";
                 var content = await client.GetStringAsync(url);
@@ -257,8 +295,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldSelectManyDetails() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldSelectManyDetails()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$selectMany={WebUtility.UrlEncode("o => o.OrderDetails")}";
                 var content = await client.GetStringAsync(url);
@@ -272,8 +312,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteAggregate() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteAggregate()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
 
                 var url1 = $"api/Test/Orders?$select=Price&$aggregate={WebUtility.UrlEncode("(p1, p2) => p1 + p2")}";
@@ -295,8 +337,10 @@ namespace Linquest.AspNetCore.Tests {
 
 
         [Fact]
-        public async Task ShouldExecuteAll() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteAll()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$all={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -307,8 +351,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteAny() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteAny()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$any={WebUtility.UrlEncode("o => o.Id < 3")}";
                 var content = await client.GetStringAsync(url);
@@ -319,8 +365,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteAvg() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteAvg()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$avg={WebUtility.UrlEncode("o => o.Id")}";
                 var content = await client.GetStringAsync(url);
@@ -331,8 +379,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteMax() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteMax()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$max={WebUtility.UrlEncode("o => o.Price")}";
                 var content = await client.GetStringAsync(url);
@@ -343,8 +393,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteMin() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteMin()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$min={WebUtility.UrlEncode("o => o.Price")}";
                 var content = await client.GetStringAsync(url);
@@ -355,8 +407,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteSum() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteSum()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$sum={WebUtility.UrlEncode("o => o.Price")}";
                 var content = await client.GetStringAsync(url);
@@ -367,8 +421,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldExecuteCount() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldExecuteCount()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$count={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -379,8 +435,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetFirstOrder() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetFirstOrder()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$first={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -392,8 +450,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingFirstOrder() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetNullForNonExistingFirstOrder()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$firstOrDefault={WebUtility.UrlEncode("o => o.Id > 5")}";
                 var content = await client.GetStringAsync(url);
@@ -404,8 +464,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetSingleOrder() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetSingleOrder()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$single={WebUtility.UrlEncode("o => o.Id > 4")}";
                 var content = await client.GetStringAsync(url);
@@ -417,8 +479,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingSingleOrder() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetNullForNonExistingSingleOrder()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$singleOrDefault={WebUtility.UrlEncode("o => o.Id > 5")}";
                 var content = await client.GetStringAsync(url);
@@ -429,8 +493,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetLastOrder() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetLastOrder()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$last={WebUtility.UrlEncode("o => o.Id > 2")}";
                 var content = await client.GetStringAsync(url);
@@ -442,8 +508,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingLastOrder() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetNullForNonExistingLastOrder()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$lastOrDefault={WebUtility.UrlEncode("o => o.Id > 5")}";
                 var content = await client.GetStringAsync(url);
@@ -454,8 +522,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetElementAtIndex() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetElementAtIndex()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = "api/Test/Orders?$elementAt=3";
                 var content = await client.GetStringAsync(url);
@@ -467,8 +537,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingElementAtIndex() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldGetNullForNonExistingElementAtIndex()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$elementAtOrDefault=5";
                 var content = await client.GetStringAsync(url);
@@ -479,8 +551,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldReverseOrders() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldReverseOrders()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$reverse";
                 var content = await client.GetStringAsync(url);
@@ -494,8 +568,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldUseCustomHandler() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldUseCustomHandler()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/GetAProduct";
                 var content = await client.GetStringAsync(url);
@@ -506,8 +582,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldThrowWhenMaxCountExceeded() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldThrowWhenMaxCountExceeded()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
                 var content = await client.GetStringAsync("api/Test/LimitedOrders?$take=3");
                 var dynContent = JObject.Parse(content);
@@ -520,8 +598,10 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public async Task ShouldThrowForUnsupportedQuery() {
-            using (var testServer = CreateTestServer()) {
+        public async Task ShouldThrowForUnsupportedQuery()
+        {
+            using (var testServer = CreateTestServer())
+            {
                 var client = testServer.CreateClient();
 
                 await Assert.ThrowsAsync<Exception>(() => client.GetStringAsync("api/Test/Orders?$intersect"));
@@ -529,20 +609,22 @@ namespace Linquest.AspNetCore.Tests {
         }
 
         [Fact]
-        public void ShouldCheckArguments() {
+        public void ShouldCheckArguments()
+        {
             var handler = new QueryableHandler();
             var orders = Consts.Orders.AsQueryable();
 
             Assert.Throws<ArgumentNullException>(() => handler.HandleContent(null, null));
             Assert.Throws<ArgumentNullException>(() => handler.HandleContent(orders, null));
 
-            var handled = handler.HandleContent((object)orders, new ActionContext(null, orders, null, null));
+            var handled = handler.HandleContent((object) orders, new ActionContext(null, orders, null, null));
 
             Assert.Equal(orders.ToList(), handled.Result);
             Assert.NotNull(handled.Context);
         }
 
-        private TestServer CreateTestServer() {
+        private TestServer CreateTestServer()
+        {
             var builder = new WebHostBuilder()
                 .UseStartup<Startup>();
             return new TestServer(builder);

--- a/test/Linquest.AspNetCore.Tests/QueryTests.cs
+++ b/test/Linquest.AspNetCore.Tests/QueryTests.cs
@@ -10,18 +10,15 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace Linquest.AspNetCore.Tests
-{
+namespace Linquest.AspNetCore.Tests {
     using Fixture;
     using Fixture.Model;
 
-    public class QueryTests
-    {
+    public class QueryTests {
+
         [Fact]
-        public async Task ShouldAccessController()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldAccessController() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var value = await client.GetStringAsync("api/Test");
 
@@ -30,10 +27,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldReturnNull()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldReturnNull() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var content = await client.GetStringAsync("api/Test/NullValue");
                 var dynContent = JObject.Parse(content);
@@ -43,10 +38,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetFilteredOrders()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetFilteredOrders() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -60,10 +53,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetFilteredOrdersFromNativeController()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetFilteredOrdersFromNativeController() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test2/Orders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -77,10 +68,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldNotFilterEnumerableOrders()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldNotFilterEnumerableOrders() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/EnumerableOrders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -92,10 +81,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldNotFilterNonLinquestOrders()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldNotFilterNonLinquestOrders() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/NonLinquestOrders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -106,10 +93,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldSkipJsonResult()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldSkipJsonResult() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/JsonOrders?$where={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -121,10 +106,8 @@ namespace Linquest.AspNetCore.Tests
 
 
         [Fact]
-        public async Task ShouldGetSortedOrders()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetSortedOrders() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
 
                 var url1 = $"api/Test/Orders?$orderBy={WebUtility.UrlEncode("o => o.Price")}&$thenByDescending={WebUtility.UrlEncode("o => o.Id")}";
@@ -148,10 +131,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldProjectOrders()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldProjectOrders() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$select={WebUtility.UrlEncode("o => new { o.Id, o.No }")}";
                 var content = await client.GetStringAsync(url);
@@ -166,10 +147,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetOrdersIdGreaterThan2()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetOrdersIdGreaterThan2() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$skipWhile={WebUtility.UrlEncode("o => o.Id < 3")}";
                 var content = await client.GetStringAsync(url);
@@ -183,10 +162,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetOrdersIdLessThan3()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetOrdersIdLessThan3() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$takeWhile={WebUtility.UrlEncode("o => o.Id < 3")}";
                 var content = await client.GetStringAsync(url);
@@ -200,10 +177,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetPageData()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetPageData() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
 
                 var url1 = "api/Test/Orders?$inlineCount=allpages&$skip=2&$take=2";
@@ -242,10 +217,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGroupByCustomer()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGroupByCustomer() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
 
                 var url1 = $"api/Test/Orders?$groupBy={WebUtility.UrlEncode("o => o.Price")};{WebUtility.UrlEncode("(k, g) => g.Count()")}";
@@ -253,7 +226,7 @@ namespace Linquest.AspNetCore.Tests
                 var dynContent1 = JObject.Parse(content1);
                 var counts = dynContent1["d"].ToObject<List<int>>();
 
-                Assert.Equal(new[] {1, 1, 2, 1}, counts);
+                Assert.Equal(new[] { 1, 1, 2, 1 }, counts);
 
                 var url2 = $"api/Test/Orders?$groupBy={WebUtility.UrlEncode("o => o.Price")}";
                 var content2 = await client.GetStringAsync(url2);
@@ -264,7 +237,7 @@ namespace Linquest.AspNetCore.Tests
                 Assert.Single(groups2[1]);
                 Assert.Equal(2, groups2[2].Count);
                 Assert.Single(groups2[3]);
-                
+
                 var url3 = $"api/Test/Orders?$groupBy={WebUtility.UrlEncode("o => o.Price")};{WebUtility.UrlEncode("(k, g) => g")}";
                 var content3 = await client.GetStringAsync(url3);
                 var dynContent3 = JObject.Parse(content3);
@@ -281,10 +254,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetDistinctPriceCount()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetDistinctPriceCount() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$select={WebUtility.UrlEncode("o => o.Price")}&$distinct&$count";
                 var content = await client.GetStringAsync(url);
@@ -295,10 +266,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldSelectManyDetails()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldSelectManyDetails() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$selectMany={WebUtility.UrlEncode("o => o.OrderDetails")}";
                 var content = await client.GetStringAsync(url);
@@ -312,10 +281,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteAggregate()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteAggregate() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
 
                 var url1 = $"api/Test/Orders?$select=Price&$aggregate={WebUtility.UrlEncode("(p1, p2) => p1 + p2")}";
@@ -337,10 +304,8 @@ namespace Linquest.AspNetCore.Tests
 
 
         [Fact]
-        public async Task ShouldExecuteAll()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteAll() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$all={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -351,10 +316,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteAny()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteAny() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$any={WebUtility.UrlEncode("o => o.Id < 3")}";
                 var content = await client.GetStringAsync(url);
@@ -365,10 +328,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteAvg()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteAvg() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$avg={WebUtility.UrlEncode("o => o.Id")}";
                 var content = await client.GetStringAsync(url);
@@ -379,10 +340,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteMax()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteMax() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$max={WebUtility.UrlEncode("o => o.Price")}";
                 var content = await client.GetStringAsync(url);
@@ -393,10 +352,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteMin()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteMin() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$min={WebUtility.UrlEncode("o => o.Price")}";
                 var content = await client.GetStringAsync(url);
@@ -407,10 +364,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteSum()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteSum() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$sum={WebUtility.UrlEncode("o => o.Price")}";
                 var content = await client.GetStringAsync(url);
@@ -421,10 +376,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldExecuteCount()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldExecuteCount() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$count={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -435,10 +388,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetFirstOrder()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetFirstOrder() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$first={WebUtility.UrlEncode("o => o.Id > 3")}";
                 var content = await client.GetStringAsync(url);
@@ -450,10 +401,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingFirstOrder()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetNullForNonExistingFirstOrder() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$firstOrDefault={WebUtility.UrlEncode("o => o.Id > 5")}";
                 var content = await client.GetStringAsync(url);
@@ -464,10 +413,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetSingleOrder()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetSingleOrder() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$single={WebUtility.UrlEncode("o => o.Id > 4")}";
                 var content = await client.GetStringAsync(url);
@@ -479,10 +426,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingSingleOrder()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetNullForNonExistingSingleOrder() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$singleOrDefault={WebUtility.UrlEncode("o => o.Id > 5")}";
                 var content = await client.GetStringAsync(url);
@@ -493,10 +438,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetLastOrder()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetLastOrder() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$last={WebUtility.UrlEncode("o => o.Id > 2")}";
                 var content = await client.GetStringAsync(url);
@@ -508,10 +451,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingLastOrder()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetNullForNonExistingLastOrder() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$lastOrDefault={WebUtility.UrlEncode("o => o.Id > 5")}";
                 var content = await client.GetStringAsync(url);
@@ -522,10 +463,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetElementAtIndex()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetElementAtIndex() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = "api/Test/Orders?$elementAt=3";
                 var content = await client.GetStringAsync(url);
@@ -537,10 +476,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldGetNullForNonExistingElementAtIndex()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldGetNullForNonExistingElementAtIndex() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$elementAtOrDefault=5";
                 var content = await client.GetStringAsync(url);
@@ -551,10 +488,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldReverseOrders()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldReverseOrders() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/Orders?$reverse";
                 var content = await client.GetStringAsync(url);
@@ -568,10 +503,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldUseCustomHandler()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldUseCustomHandler() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var url = $"api/Test/GetAProduct";
                 var content = await client.GetStringAsync(url);
@@ -582,10 +515,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldThrowWhenMaxCountExceeded()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldThrowWhenMaxCountExceeded() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
                 var content = await client.GetStringAsync("api/Test/LimitedOrders?$take=3");
                 var dynContent = JObject.Parse(content);
@@ -598,10 +529,8 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ShouldThrowForUnsupportedQuery()
-        {
-            using (var testServer = CreateTestServer())
-            {
+        public async Task ShouldThrowForUnsupportedQuery() {
+            using (var testServer = CreateTestServer()) {
                 var client = testServer.CreateClient();
 
                 await Assert.ThrowsAsync<Exception>(() => client.GetStringAsync("api/Test/Orders?$intersect"));
@@ -609,22 +538,20 @@ namespace Linquest.AspNetCore.Tests
         }
 
         [Fact]
-        public void ShouldCheckArguments()
-        {
+        public void ShouldCheckArguments() {
             var handler = new QueryableHandler();
             var orders = Consts.Orders.AsQueryable();
 
             Assert.Throws<ArgumentNullException>(() => handler.HandleContent(null, null));
             Assert.Throws<ArgumentNullException>(() => handler.HandleContent(orders, null));
 
-            var handled = handler.HandleContent((object) orders, new ActionContext(null, orders, null, null));
+            var handled = handler.HandleContent((object)orders, new ActionContext(null, orders, null, null));
 
             Assert.Equal(orders.ToList(), handled.Result);
             Assert.NotNull(handled.Context);
         }
 
-        private TestServer CreateTestServer()
-        {
+        private TestServer CreateTestServer() {
             var builder = new WebHostBuilder()
                 .UseStartup<Startup>();
             return new TestServer(builder);


### PR DESCRIPTION
## Change list

I've added .NET Core 3.0 support.
Linquest.AspNetCore project now supports multiple frameworks `netstandard2.0` and `netcoreapp3.0`.
 
## Types of changes

What types of changes are you proposing/introducing?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

- There is no breaking changes except one little point. I want to discuss this part in the comments.
- I've updated the *appveyor.yml* to use *Visual Studio 2019* image and increased the version to 3.0.
- By the way I've used the Rider IDE on Mac. Maybe line endings or formattings differs from your version :/